### PR TITLE
added default identifier

### DIFF
--- a/Sources/PostgreSQL/Utilities/PostgreSQLProvider.swift
+++ b/Sources/PostgreSQL/Utilities/PostgreSQLProvider.swift
@@ -3,8 +3,14 @@ import Service
 
 /// Provides base `PostgreSQL` services such as database and connection.
 public final class PostgreSQLProvider: Provider {
+    let defaultIdentifier: DatabaseIdentifier<PostgreSQLDatabase>
+    
     /// Creates a new `PostgreSQLProvider`.
-    public init() {}
+    ///
+    /// - Parameter defaultIdentifier: Set the default identifier for the required Database.
+    public init(defaultIdentifier: DatabaseIdentifier<PostgreSQLDatabase> = .psql) {
+        self.defaultIdentifier = defaultIdentifier
+    }
 
     /// See `Provider.register`
     public func register(_ services: inout Services) throws {
@@ -12,7 +18,7 @@ public final class PostgreSQLProvider: Provider {
         services.register(PostgreSQLDatabaseConfig.self)
         services.register(PostgreSQLDatabase.self)
         var databases = DatabasesConfig()
-        databases.add(database: PostgreSQLDatabase.self, as: .psql)
+        databases.add(database: PostgreSQLDatabase.self, as: self.defaultIdentifier)
         services.register(databases)
     }
 

--- a/Sources/PostgreSQL/Utilities/PostgreSQLProvider.swift
+++ b/Sources/PostgreSQL/Utilities/PostgreSQLProvider.swift
@@ -3,13 +3,13 @@ import Service
 
 /// Provides base `PostgreSQL` services such as database and connection.
 public final class PostgreSQLProvider: Provider {
-    let defaultIdentifier: DatabaseIdentifier<PostgreSQLDatabase>
+    let identifier: DatabaseIdentifier<PostgreSQLDatabase>
     
     /// Creates a new `PostgreSQLProvider`.
     ///
-    /// - Parameter defaultIdentifier: Set the default identifier for the required Database.
-    public init(defaultIdentifier: DatabaseIdentifier<PostgreSQLDatabase> = .psql) {
-        self.defaultIdentifier = defaultIdentifier
+    /// - Parameter identifier: the default identifier for the required Database.
+    public init(default identifier: DatabaseIdentifier<PostgreSQLDatabase> = .psql) {
+        self.identifier = identifier
     }
 
     /// See `Provider.register`
@@ -18,7 +18,7 @@ public final class PostgreSQLProvider: Provider {
         services.register(PostgreSQLDatabaseConfig.self)
         services.register(PostgreSQLDatabase.self)
         var databases = DatabasesConfig()
-        databases.add(database: PostgreSQLDatabase.self, as: self.defaultIdentifier)
+        databases.add(database: PostgreSQLDatabase.self, as: self.identifier)
         services.register(databases)
     }
 


### PR DESCRIPTION
This PR prevent this error...
```
Fatal error: Error raised at top level: ⚠️ DatabaseKit Error: No database with id 'psql' is configured.
- id: DatabaseKitError.dbRequired
```
... when you register one or more databases with custom identifiers but none is . psql

Related to: vapor/fluent-postgresql#81