### PR TITLE
Add support for PostgreSQL urls to unix sockets

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+ServerAddress.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+ServerAddress.swift
@@ -12,8 +12,17 @@ extension PostgreSQLConnection {
         }
         
         /// TCP PostgreSQL address.
+        ///
+        /// - note: If the hostname begins with a slash, this method actually returns a Unix socket PostgreSQL address.
+        ///         `hostname` is used as the path of the directory in which the socket file is stored and `port` as the
+        ///         socket file extension.
         public static func tcp(hostname: String, port: Int) -> ServerAddress {
-            return .init(.tcp(hostname: hostname, port: port))
+            if hostname.hasPrefix("/") {
+                let path = "\(hostname)/.s.PGSQL.\(port)"
+                return .unixSocket(path: path)
+            } else {
+                return .init(.tcp(hostname: hostname, port: port))
+            }
         }
         
         /// Unix socket PostgreSQL address.


### PR DESCRIPTION
This copies the behavior of [libpq](https://www.postgresql.org/docs/10/static/libpq-connect.html):
> If a host name begins with a slash, it specifies Unix-domain communication rather than TCP/IP communication; the value is the name of the directory in which the socket file is stored.

As the slash is a reserved character in the hierarchical part of the url, it needs to be percent-encoded as `%2F` (example: `postgresql://postgres@%2Fprivate%2Ftmp%2F/vapor`).