### PR TITLE
Support providing hostname of server while adding SSL client handler

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+Connect.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+Connect.swift
@@ -32,7 +32,7 @@ extension PostgreSQLConnection {
             case .cleartext:
                 return worker.future(connection)
             case .tls(let tlsConfig):
-                return connection.addSSLClientHandler(using: tlsConfig).transform(to: connection)
+                return connection.addSSLClientHandler(using: tlsConfig, forHost: serverAddress.hostname).transform(to: connection)
             }
         }
     }

--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection+ServerAddress.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection+ServerAddress.swift
@@ -5,27 +5,36 @@ extension PostgreSQLConnection {
         public static var `default`: ServerAddress {
             return .tcp(hostname: "localhost", port: 5432)
         }
-        
+
         /// Default PostgreSQL socket file.
         public static var socketDefault: ServerAddress {
             return .unixSocket(path: "/tmp/.s.PGSQL.5432")
         }
-        
+
         /// TCP PostgreSQL address.
         public static func tcp(hostname: String, port: Int) -> ServerAddress {
             return .init(.tcp(hostname: hostname, port: port))
         }
-        
+
         /// Unix socket PostgreSQL address.
         public static func unixSocket(path: String) -> ServerAddress {
             return .init(.unixSocket(path: path))
         }
-        
+
         /// Custom PostgreSQL socket address.
         public static func socketAddress(_ socketAddress: SocketAddress) -> ServerAddress {
             return .init(.socketAddress(socketAddress))
         }
-        
+
+        /// Returns the hostname of the server (if any).
+        public var hostname: String? {
+            if case .tcp(let name, _) = storage {
+                return name
+            }
+
+            return nil
+        }
+
         /// Internal storage type.
         enum Storage {
             /// Connect via TCP using the given hostname and port.


### PR DESCRIPTION
Let's say that I'm using this driver in a program (client) to communicate with a database *securely* (i.e., with TLS). The certificate provided by the database is valid for a bunch of host names and/or IP addresses (available in SANs). It's okay to use IP addresses, but it's also common to use hostnames, because routing can be done to appropriate clusters without having to change the certs every time we change the node.

Currently, this driver doesn't pass the hostname (it expects) to NIO-SSL. In NIO-SSL, the verification happens [here](https://github.com/apple/swift-nio-ssl/blob/5c522115a3696701255b0a086508c9ea892584d4/Sources/NIOOpenSSL/OpenSSLHandler.swift#L380), i.e., [this function](https://github.com/apple/swift-nio-ssl/blob/5c522115a3696701255b0a086508c9ea892584d4/Sources/NIOOpenSSL/IdentityVerification.swift#L106). Without the expected hostname, it defaults to verifying IP addresses, which fails even if the certificates are valid.

This patch adds that support by getting the hostname from the connection (if it's TCP) and initializing it in the SSL client handler.

As a sidenote, thanks for maintaining this driver! It's been very helpful to our project. You folks are awesome! :)