### PR TITLE
publicize _executeCloseHandlersThenClose

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -122,11 +122,11 @@ public final class PostgreSQLConnection: DatabaseConnection, BasicWorker, Databa
 
     /// Closes this client.
     public func close() {
-        _ = executeCloseHandlersThenClose()
+        _ = _executeCloseHandlersThenClose()
     }
 
     /// Executes close handlers before closing.
-    private  func executeCloseHandlersThenClose() -> Future<Void> {
+    public func _executeCloseHandlersThenClose() -> Future<Void> {
         return channel.close(mode: .all)
     }
 


### PR DESCRIPTION
Publicizes `PostgreSQLConnection._executeCloseHandlersThenClose()` as an async way to close a connection. Note this method is prefixed with `_` to indicate it will be going away in the next version as `close()` itself will be async.

Fixes #124