### PR TITLE
close conn if auth fails

### DIFF
--- a/Sources/PostgresKit/PostgresConnectionSource.swift
+++ b/Sources/PostgresKit/PostgresConnectionSource.swift
@@ -23,7 +23,10 @@ public struct PostgresConnectionSource: ConnectionPoolSource {
                 username: self.configuration.username,
                 database: self.configuration.database,
                 password: self.configuration.password
-            ).map { conn }
+            ).flatMapError { error in
+                return conn.close()
+                    .flatMapThrowing { throw error }
+            }.map { conn }
         }
     }
 }


### PR DESCRIPTION
Fixes an issue in `PostgresConnectionSource` where the connection would not be closed (resulting in an assertion) if an error happened during authentication. 