### PR TITLE
make stacktrace optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /*.xcodeproj
 Package.resolved
 DerivedData
+.swiftpm
 

--- a/Sources/PostgreSQL/Utilities/PostgreSQLError.swift
+++ b/Sources/PostgreSQL/Utilities/PostgreSQLError.swift
@@ -25,7 +25,7 @@ public struct PostgreSQLError: Debuggable {
     public var sourceLocation: SourceLocation
     
     /// See `Debuggable`.
-    public var stackTrace: [String]
+    public var stackTrace: [String]?
     
     /// See `Debuggable`.
     public var possibleCauses: [String]


### PR DESCRIPTION
Fixes https://github.com/vapor/postgres-kit/issues/146