### PR TITLE
Fix Arbitrary Encodable Type to JSON Encoding

### DIFF
--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -12,11 +12,7 @@ public struct PostgresDataEncoder {
                 try value.encode(to: encoder)
                 return encoder.data
             } catch is DoJSON {
-                let json = JSONEncoder()
-                let data = try json.encode(Wrapper(value))
-                var buffer = ByteBufferAllocator().buffer(capacity: data.count)
-                buffer.writeBytes(data)
-                return PostgresData(type: .jsonb, value: buffer)
+                return try PostgresData(jsonb: Wrapper(value))
             }
         }
     }


### PR DESCRIPTION
When encoding arbitrary encodable types to JSON for `PostgresData`, the JSONB version number was not being appended to the JSON data, causing an `unsupported json version number` error.