### PR TITLE
postgres data encoder refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,25 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: swift test --enable-test-discovery --sanitize=thread
+  fluent:
+    container: 
+      image: vapor/swift:5.1
+    services:
+      psql:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: vapor_username
+          POSTGRES_DB: vapor_database
+          POSTGRES_PASSWORD: vapor_password
+    runs-on: ubuntu-latest
+    steps:
+    - run: git clone -b master https://github.com/vapor/fluent-postgres-driver.git
+      working-directory: ./
+    - run: swift package edit postgres-kit --revision ${{ github.sha }}
+      working-directory: ./fluent-postgres-driver
+    - run: swift test --enable-test-discovery --sanitize=thread
+      working-directory: ./fluent-postgres-driver
+      env:
+        POSTGRES_HOSTNAME: psql

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -20,17 +20,15 @@ public final class PostgresDataEncoder {
             switch data {
             case .array(let array):
                 return try PostgresData(
-                    array: array.map {
-                        try PostgresData(
-                            jsonb: self.json.encode(Wrapper($0))
-                        )
+                    array: array.map { item in
+                        let data = try self.json.encode(item)
+                        return PostgresData(jsonb: data)
                     },
                     elementType: .jsonb
                 )
             case .dictionary(let dictionary):
-                return try PostgresData(
-                    jsonb: self.json.encode(Wrapper(dictionary))
-                )
+                let data = try self.json.encode(dictionary)
+                return PostgresData(jsonb: data)
             case .null:
                 return .null
             case .encodable(let encodable):

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -20,11 +20,17 @@ public final class PostgresDataEncoder {
             switch data {
             case .array(let array):
                 return try PostgresData(
-                    array: array.map { try PostgresData(jsonb: self.json.encode($0)) },
+                    array: array.map {
+                        try PostgresData(
+                            jsonb: self.json.encode(Wrapper($0))
+                        )
+                    },
                     elementType: .jsonb
                 )
             case .dictionary(let dictionary):
-                return try PostgresData(jsonb: self.json.encode(dictionary))
+                return try PostgresData(
+                    jsonb: self.json.encode(Wrapper(dictionary))
+                )
             case .null:
                 return .null
             case .encodable(let encodable):

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -13,14 +13,14 @@ public final class PostgresDataEncoder {
         } else {
             let encoder = _Encoder(codingPath: [])
             try Wrapper(value).encode(to: encoder)
-            guard let data = encoder.data?.resolve() else {
+            guard let data: _Value = encoder.data?.resolve() else {
                 // no containers made
                 return .null
             }
             switch data {
             case .array(let array):
                 return try PostgresData(
-                    array: array.map { item -> PostgresData in
+                    array: array.map { (item: _Value) -> PostgresData in
                         let data = try self.json.encode(item)
                         return PostgresData(jsonb: data)
                     },

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -20,7 +20,7 @@ public final class PostgresDataEncoder {
             switch data {
             case .array(let array):
                 return try PostgresData(
-                    array: array.map { item in
+                    array: array.map { item -> PostgresData in
                         let data = try self.json.encode(item)
                         return PostgresData(jsonb: data)
                     },

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -1,167 +1,258 @@
 import Foundation
 
 public final class PostgresDataEncoder {
-    public let jsonEncoder: JSONEncoder
+    public let json: JSONEncoder
 
     public init(json: JSONEncoder = JSONEncoder()) {
-        self.jsonEncoder = json
+        self.json = json
     }
 
     public func encode(_ value: Encodable) throws -> PostgresData {
         if let custom = value as? PostgresDataConvertible {
             return custom.postgresData!
         } else {
-            do {
-                let encoder = _Encoder()
-                try value.encode(to: encoder)
-                return encoder.data
-            } catch is DoJSON {
-                let data = try self.jsonEncoder.encode(Wrapper(value))
-                return PostgresData(jsonb: data)
+            let encoder = _Encoder(codingPath: [])
+            try Wrapper(value).encode(to: encoder)
+            guard let data = encoder.data?.resolve() else {
+                // no containers made
+                return .null
+            }
+            switch data {
+            case .array(let array):
+                return try PostgresData(
+                    array: array.map { try PostgresData(jsonb: self.json.encode($0)) },
+                    elementType: .jsonb
+                )
+            case .dictionary(let dictionary):
+                return try PostgresData(jsonb: self.json.encode(dictionary))
+            case .null:
+                return .null
+            case .encodable(let encodable):
+                return try self.encode(encodable)
             }
         }
     }
+}
 
-    private final class _Encoder: Encoder {
-        var codingPath: [CodingKey] {
-            return []
-        }
-
-        var userInfo: [CodingUserInfoKey : Any] {
-            return [:]
-        }
-        var data: PostgresData
-        init() {
-            self.data = .null
-        }
-
-        func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-            .init(_KeyedValueEncoder(self))
-        }
-
-        func unkeyedContainer() -> UnkeyedEncodingContainer {
-            _UnkeyedEncodingContainer(self)
-        }
-
-        func singleValueContainer() -> SingleValueEncodingContainer {
-            _SingleValueEncoder(self)
-        }
+private final class _Encoder: Encoder {
+    var userInfo: [CodingUserInfoKey : Any] {
+        return [:]
+    }
+    var codingPath: [CodingKey]
+    var data: _Data?
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
     }
 
-    struct DoJSON: Error {}
-
-    struct Wrapper: Encodable {
-        let encodable: Encodable
-        init(_ encodable: Encodable) {
-            self.encodable = encodable
-        }
-        func encode(to encoder: Encoder) throws {
-            try self.encodable.encode(to: encoder)
-        }
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key>
+        where Key : CodingKey
+    {
+        let container = _KeyedEncoder<Key>(codingPath: self.codingPath)
+        self.data = .container(container)
+        return .init(container)
     }
 
-    private struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer {
-        var codingPath: [CodingKey] {
-            self.encoder.codingPath
-        }
-        var count: Int {
-            0
-        }
-
-        let encoder: _Encoder
-        init(_ encoder: _Encoder) {
-            self.encoder = encoder
-        }
-
-        mutating func encodeNil() throws {
-            throw DoJSON()
-        }
-
-        mutating func encode<T>(_ value: T) throws where T : Encodable {
-            throw DoJSON()
-        }
-
-        mutating func nestedContainer<NestedKey>(
-            keyedBy keyType: NestedKey.Type
-        ) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-            self.encoder.container(keyedBy: NestedKey.self)
-        }
-
-        mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-            self.encoder.unkeyedContainer()
-        }
-
-        mutating func superEncoder() -> Encoder {
-            self.encoder
-        }
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = _UnkeyedEncoder(codingPath: self.codingPath)
+        self.data = .container(container)
+        return container
     }
 
-    private struct _KeyedValueEncoder<Key>: KeyedEncodingContainerProtocol where Key: CodingKey {
-        var codingPath: [CodingKey] {
-            self.encoder.codingPath
-        }
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        let container = _ValueEncoder(codingPath: self.codingPath)
+        self.data = .container(container)
+        return container
+    }
+}
 
-        let encoder: _Encoder
-        init(_ encoder: _Encoder) {
-            self.encoder = encoder
-        }
+private final class _UnkeyedEncoder: UnkeyedEncodingContainer, _Container {
+    var codingPath: [CodingKey]
+    var count: Int {
+        self.items.count
+    }
+    var data: _Data {
+        .array(self.items)
+    }
+    var items: [_Data]
 
-        mutating func encodeNil(forKey key: Key) throws {
-            throw DoJSON()
-        }
-
-        mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
-            throw DoJSON()
-        }
-
-        mutating func nestedContainer<NestedKey>(
-            keyedBy keyType: NestedKey.Type,
-            forKey key: Key
-        ) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-            self.encoder.container(keyedBy: NestedKey.self)
-        }
-
-        mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-            self.encoder.unkeyedContainer()
-        }
-
-        mutating func superEncoder() -> Encoder {
-            self.encoder
-        }
-
-        mutating func superEncoder(forKey key: Key) -> Encoder {
-            self.encoder
-        }
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+        self.items = []
     }
 
+    func encodeNil() throws {
+        self.items.append(.null)
+    }
 
-    private struct _SingleValueEncoder: SingleValueEncodingContainer {
-        var codingPath: [CodingKey] {
-            return self.encoder.codingPath
-        }
+    func encode<T>(_ value: T) throws where T : Encodable {
+        self.items.append(.encodable(value))
+    }
 
-        let encoder: _Encoder
-        init(_ encoder: _Encoder) {
-            self.encoder = encoder
-        }
+    func nestedContainer<NestedKey>(
+        keyedBy keyType: NestedKey.Type
+    ) -> KeyedEncodingContainer<NestedKey>
+        where NestedKey : CodingKey
+    {
+        let container = _KeyedEncoder<NestedKey>(codingPath: self.codingPath)
+        self.items.append(.container(container))
+        return .init(container)
+    }
 
-        mutating func encodeNil() throws {
-            // data already null
-        }
+    func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = _UnkeyedEncoder(codingPath: self.codingPath)
+        self.items.append(.container(container))
+        return container
+    }
 
-        mutating func encode<T>(_ value: T) throws where T : Encodable {
-            if let value = value as? PostgresDataConvertible {
-                guard let data = value.postgresData else {
-                    let context = DecodingError.Context(
-                        codingPath: self.codingPath,
-                        debugDescription: "Could not convert \(value) to PostgresData"
-                    )
-                    throw DecodingError.typeMismatch(T.self, context)
-                }
-                self.encoder.data = data
-            } else {
-                try value.encode(to: self.encoder)
+    func superEncoder() -> Encoder {
+        _Encoder(codingPath: self.codingPath)
+    }
+}
+
+private final class _KeyedEncoder<Key>: KeyedEncodingContainerProtocol, _Container
+    where Key: CodingKey
+{
+    var codingPath: [CodingKey]
+    var data: _Data {
+        .dictionary(self.items)
+    }
+    var items: [String: _Data]
+
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+        self.items = [:]
+    }
+
+    func encodeNil(forKey key: Key) throws {
+        self.items[key.stringValue] = .null
+    }
+
+    func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        self.items[key.stringValue] = .encodable(value)
+    }
+
+    func nestedContainer<NestedKey>(
+        keyedBy keyType: NestedKey.Type,
+        forKey key: Key
+    ) -> KeyedEncodingContainer<NestedKey>
+        where NestedKey : CodingKey
+    {
+        let container = _KeyedEncoder<NestedKey>(codingPath: self.codingPath)
+        self.items[key.stringValue] = .container(container)
+        return .init(container)
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let container = _UnkeyedEncoder(codingPath: self.codingPath)
+        self.items[key.stringValue] = .container(container)
+        return container
+    }
+
+    func superEncoder() -> Encoder {
+        _Encoder(codingPath: self.codingPath)
+    }
+
+    func superEncoder(forKey key: Key) -> Encoder {
+        _Encoder(codingPath: self.codingPath + [key])
+    }
+}
+
+
+private final class _ValueEncoder: SingleValueEncodingContainer, _Container {
+    var codingPath: [CodingKey]
+    var data: _Data
+
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+        self.data = .null
+    }
+
+    func encodeNil() throws {
+        self.data = .null
+    }
+
+    func encode<T>(_ value: T) throws where T : Encodable {
+        self.data = .encodable(value)
+    }
+}
+
+struct Wrapper: Encodable {
+    let encodable: Encodable
+    init(_ encodable: Encodable) {
+        self.encodable = encodable
+    }
+    func encode(to encoder: Encoder) throws {
+        try self.encodable.encode(to: encoder)
+    }
+}
+
+protocol _Container {
+    var data: _Data { get }
+}
+
+enum _Value: Encodable {
+    case array([_Value])
+    case dictionary([String: _Value])
+    case null
+    case encodable(Encodable)
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .array(let array):
+            var container = encoder.unkeyedContainer()
+            try array.forEach { try container.encode($0) }
+        case .dictionary(let dictionary):
+            var container = encoder.container(keyedBy: _Key.self)
+            try dictionary.forEach {
+                try container.encode($0.value, forKey: .init($0.key))
             }
+        case .null:
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        case .encodable(let encodable):
+            try encodable.encode(to: encoder)
+        }
+    }
+}
+
+struct _Key: CodingKey {
+    var stringValue: String
+    var intValue: Int? {
+        Int(self.stringValue)
+    }
+
+    init(_ string: String) {
+        self.stringValue = string
+    }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = intValue.description
+    }
+}
+
+enum _Data {
+    case array([_Data])
+    case dictionary([String: _Data])
+    case null
+    case container(_Container)
+    case encodable(Encodable)
+
+    func resolve() -> _Value {
+        switch self {
+        case .array(let array):
+            return .array(array.map { $0.resolve() })
+        case .dictionary(let dictionary):
+            return .dictionary(dictionary.mapValues { $0.resolve() })
+        case .null:
+            return .null
+        case .container(let container):
+            return container.data.resolve()
+        case .encodable(let encodable):
+            return .encodable(encodable)
         }
     }
 }

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -13,22 +13,20 @@ public final class PostgresDataEncoder {
         } else {
             let encoder = _Encoder(codingPath: [])
             try Wrapper(value).encode(to: encoder)
-            guard let data: _Value = encoder.data?.resolve() else {
+            guard let data = encoder.data?.resolve() else {
                 // no containers made
                 return .null
             }
             switch data {
             case .array(let array):
                 return try PostgresData(
-                    array: array.map { (item: _Value) -> PostgresData in
-                        let data = try self.json.encode(item)
-                        return PostgresData(jsonb: data)
+                    array: array.map {
+                        try PostgresData(jsonb: self.json.encode($0))
                     },
                     elementType: .jsonb
                 )
             case .dictionary(let dictionary):
-                let data = try self.json.encode(dictionary)
-                return PostgresData(jsonb: data)
+                return try PostgresData(jsonb: self.json.encode(dictionary))
             case .null:
                 return .null
             case .encodable(let encodable):

--- a/Sources/PostgresKit/PostgresRow+SQL.swift
+++ b/Sources/PostgresKit/PostgresRow+SQL.swift
@@ -12,12 +12,13 @@ private struct _PostgreSQLRow: SQLRow {
         case missingColumn(String)
     }
 
-    var columns: [String] {
-        self.row.columns
+    var allColumns: [String] {
+        self.row.rowDescription.fields.map { $0.name }
     }
 
     func contains(column: String) -> Bool {
-        self.row.contains(column: column)
+        self.row.rowDescription.fields
+            .contains { $0.name == column }
     }
 
     func decodeNil(column: String) throws -> Bool {

--- a/Sources/PostgresKit/PostgresRow+SQL.swift
+++ b/Sources/PostgresKit/PostgresRow+SQL.swift
@@ -8,9 +8,25 @@ private struct _PostgreSQLRow: SQLRow {
     let row: PostgresRow
     let decoder: PostgresDataDecoder
 
+    enum _Error: Error {
+        case missingColumn(String)
+    }
+
+    var columns: [String] {
+        self.row.columns
+    }
+
+    func contains(column: String) -> Bool {
+        self.row.contains(column: column)
+    }
+
+    func decodeNil(column: String) throws -> Bool {
+        self.row.column(column) == nil
+    }
+
     func decode<D>(column: String, as type: D.Type) throws -> D where D : Decodable {
         guard let data = self.row.column(column) else {
-            fatalError()
+            throw _Error.missingColumn(column)
         }
         return try self.decoder.decode(D.self, from: data)
     }

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -1,6 +1,7 @@
 import PostgresKit
 import SQLKitBenchmark
 import XCTest
+import Logging
 
 class PostgresKitTests: XCTestCase {
     func testSQLKitBenchmark() throws {
@@ -113,6 +114,30 @@ class PostgresKitTests: XCTestCase {
                 .model(zipcode)
                 .run().wait()
         }
+    }
+
+    func testArrayEncoding() throws {
+        let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+        conn.logger.logLevel = .trace
+        
+        struct Foo: Codable {
+            var bar: Int
+        }
+        let foos: [Foo] = [.init(bar: 1), .init(bar: 2)]
+        try conn.sql().raw("SELECT \(bind: foos)::JSONB[] as foos")
+            .run().wait()
+    }
+
+    func testDictionaryEncoding() throws {
+        let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+        conn.logger.logLevel = .trace
+
+        struct Foo: Codable {
+            var bar: Int
+        }
+         
     }
       
     private var eventLoopGroup: EventLoopGroup!


### PR DESCRIPTION
Refactors `PostgresDataEncoder` to be more flexible. There are now three distinct paths for encoding:
- Single value: Cast to `PostgresDataConvertible`, if fail, unwrap and try again
- Unkeyed value: Convert to `JSONB[]`
- Keyed value: Convert to `JSONB`

This is achieved by encoding to a temporary structure. This structure can be analyzed when deciding how to proceed with encoding.