### PR TITLE
Add EventLoopGroupConnectionPool database convenience

### DIFF
--- a/Sources/PostgresKit/ConnectionPool+Postgres.swift
+++ b/Sources/PostgresKit/ConnectionPool+Postgres.swift
@@ -1,15 +1,40 @@
-extension EventLoopConnectionPool where Source == PostgresConnectionSource {
+extension EventLoopGroupConnectionPool where Source == PostgresConnectionSource {
     public func database(logger: Logger) -> PostgresDatabase {
-        _ConnectionPoolPostgresDatabase(pool: self, logger: logger)
+        _EventLoopGroupConnectionPoolPostgresDatabase(pool: self, logger: logger)
     }
 }
 
-private struct _ConnectionPoolPostgresDatabase {
+private struct _EventLoopGroupConnectionPoolPostgresDatabase {
+    let pool: EventLoopGroupConnectionPool<PostgresConnectionSource>
+    let logger: Logger
+}
+
+extension _EventLoopGroupConnectionPoolPostgresDatabase: PostgresDatabase {
+    var eventLoop: EventLoop { self.pool.eventLoopGroup.next() }
+
+    func send(_ request: PostgresRequest, logger: Logger) -> EventLoopFuture<Void> {
+        self.pool.withConnection(logger: logger) {
+            $0.send(request, logger: logger)
+        }
+    }
+
+    func withConnection<T>(_ closure: @escaping (PostgresConnection) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        self.pool.withConnection(logger: self.logger, closure)
+    }
+}
+
+extension EventLoopConnectionPool where Source == PostgresConnectionSource {
+    public func database(logger: Logger) -> PostgresDatabase {
+        _EventLoopConnectionPoolPostgresDatabase(pool: self, logger: logger)
+    }
+}
+
+private struct _EventLoopConnectionPoolPostgresDatabase {
     let pool: EventLoopConnectionPool<PostgresConnectionSource>
     let logger: Logger
 }
 
-extension _ConnectionPoolPostgresDatabase: PostgresDatabase {
+extension _EventLoopConnectionPoolPostgresDatabase: PostgresDatabase {
     var eventLoop: EventLoop { self.pool.eventLoop }
     
     func send(_ request: PostgresRequest, logger: Logger) -> EventLoopFuture<Void> {

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -157,6 +157,21 @@ class PostgresKitTests: XCTestCase {
         XCTAssertEqual(test.bar, nil)
         XCTAssertEqual(test.baz, "baz")
     }
+
+    func testEventLoopGroupSQL() throws {
+        let source = PostgresConnectionSource(configuration: .init(
+            hostname: hostname,
+            username: "vapor_username",
+            password: "vapor_password",
+            database: "vapor_database"
+        ))
+        let pool = EventLoopGroupConnectionPool(source: source, on: self.eventLoopGroup)
+        defer { pool.shutdown() }
+        let db = pool.database(logger: .init(label: "test")).sql()
+
+        let rows = try db.raw("SELECT version();").all().wait()
+        print(rows)
+    }
       
     private var eventLoopGroup: EventLoopGroup!
     private var eventLoop: EventLoop {


### PR DESCRIPTION
Adds a method for creating a `PostgresDatabase` from an `EventLoopGroupConnectionPool`.

```swift
let db = pool.database(logger: .init(label: "test"))
```