### PR TITLE
Use default port for URLs

### DIFF
--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -25,9 +25,7 @@ public struct PostgresConfiguration {
         guard let hostname = url.host else {
             return nil
         }
-        guard let port = url.port else {
-            return nil
-        }
+        let port = url.port ?? 5432
         
         let tlsConfiguration: TLSConfiguration?
         if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {


### PR DESCRIPTION
Adds support for database urls not containing an explicit port: `postgres://user:password@localhost/database` (#183).