### PR TITLE
Fix force unwrap in PostgresDataDecoder

### DIFF
--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -139,7 +139,12 @@ public final class PostgresDataDecoder {
 
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
             if let convertible = T.self as? PostgresDataConvertible.Type {
-                return convertible.init(postgresData: self.data)! as! T
+                guard let value = convertible.init(postgresData: data) else {
+                    throw DecodingError.typeMismatch(T.self, DecodingError.Context.init(
+                        codingPath: [],
+                        debugDescription: "Could not convert to \(T.self): \(data)"
+                    ))
+                }
             } else {
                 return try T.init(from: _Decoder(data: self.data, json: self.json))
             }

--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -145,6 +145,7 @@ public final class PostgresDataDecoder {
                         debugDescription: "Could not convert to \(T.self): \(data)"
                     ))
                 }
+                return value as! T
             } else {
                 return try T.init(from: _Decoder(data: self.data, json: self.json))
             }


### PR DESCRIPTION
Replaces a force unwrap with a `DecodingError` in `PostgresDataDecoder` (#184). 