### PR TITLE
add support for verify sslmodes

### DIFF
--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -34,7 +34,7 @@ public struct PostgresConfiguration {
         let port = url.port ?? 5432
         
         let tlsConfiguration: TLSConfiguration?
-        if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {
+        if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true || url.query?.contains("sslmode=verify") == true {
             tlsConfiguration = TLSConfiguration.forClient()
         } else {
             tlsConfiguration = nil


### PR DESCRIPTION
This adds support for `sslmode=verify-ca` and `sslmode=verify-full` query strings in `PostgresConfiguration(url:)`

Reference: https://www.postgresql.org/docs/12/libpq-ssl.html