### PR TITLE
Add optional TLSConfiguration parameter to Postgres' configuration initializer

### DIFF
--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -13,14 +13,14 @@ public struct PostgresConfiguration {
     internal var _hostname: String?
 
 
-    public init?(url: String) {
+    public init?(url: String, tlsConfiguration: TLSConfiguration? = nil) {
         guard let url = URL(string: url) else {
             return nil
         }
-        self.init(url: url)
+        self.init(url: url, tlsConfiguration: tlsConfiguration)
     }
     
-    public init?(url: URL) {
+    public init?(url: URL, tlsConfiguration tlsConfig: TLSConfiguration? = nil) {
         guard url.scheme?.hasPrefix("postgres") == true else {
             return nil
         }
@@ -32,12 +32,10 @@ public struct PostgresConfiguration {
             return nil
         }
         let port = url.port ?? 5432
-        
-        let tlsConfiguration: TLSConfiguration?
-        if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {
+
+        var tlsConfiguration = tlsConfig
+        if tlsConfiguration == nil, url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {
             tlsConfiguration = TLSConfiguration.forClient()
-        } else {
-            tlsConfiguration = nil
         }
         
         self.init(


### PR DESCRIPTION
A user should be able to call `PostgresConfiguration(url:tlsConfiguration:)`.

In environment like Heroku, where only a `DATABASE_URL` is given and some databases required SSL on, we should be able to add the `TLSConfiguration` right on when creating the `PostgresConfiguration`. Simply adding `sslmode=require` to the URL does not work as the default TLSConfiguration has TLS verification on.

Related to #186.