### PR TITLE
Make tests respect the LOG_LEVEL env var

### DIFF
--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -197,10 +197,14 @@ enum Bar: Int, Codable {
 }
 extension Bar: PostgresDataConvertible { }
 
+func env(_ name: String) -> String? {
+    getenv(name).flatMap { String(cString: $0) }
+}
+
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = .debug
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
         return handler
     }
     return true


### PR DESCRIPTION
No semver label needed, doesn't need a release