### PR TITLE
Enable RETURNING use in SQLKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.5.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/PostgresKit/PostgresDialect.swift
+++ b/Sources/PostgresKit/PostgresDialect.swift
@@ -30,6 +30,10 @@ public struct PostgresDialect: SQLDialect {
         true
     }
 
+    public var supportsReturning: Bool {
+        true
+    }
+
     public var enumSyntax: SQLEnumSyntax {
         .typeName
     }


### PR DESCRIPTION
Support for the RETURNING clause was added in SQLKit 3.5.0 (#189). 

This enables that functionality for Postgres by setting the `SQLDialect` feature flag.