### PR TITLE
Use PostgresNIO's default JSON coders

### DIFF
--- a/Sources/PostgresKit/Deprecations/PostgresDataDecoder+JSONDecoder.swift
+++ b/Sources/PostgresKit/Deprecations/PostgresDataDecoder+JSONDecoder.swift
@@ -1,0 +1,8 @@
+import class Foundation.JSONDecoder
+
+extension PostgresDataDecoder {
+    @available(*, deprecated, renamed: "json")
+    public var jsonDecoder: JSONDecoder {
+        return self.json as! JSONDecoder
+    }
+}

--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -1,11 +1,12 @@
 import Foundation
 import protocol PostgresNIO.PostgresJSONDecoder
+import var PostgresNIO._defaultJSONDecoder
 
 public final class PostgresDataDecoder {
-    public let jsonDecoder: PostgresNIO.PostgresJSONDecoder
-
+    public let json: PostgresNIO.PostgresJSONDecoder
+    
     public init(json: PostgresNIO.PostgresJSONDecoder = PostgresNIO._defaultJSONDecoder) {
-        self.jsonDecoder = json
+        self.json = json
     }
 
     public func decode<T>(_ type: T.Type, from data: PostgresData) throws -> T
@@ -20,7 +21,7 @@ public final class PostgresDataDecoder {
             }
             return value as! T
         } else {
-            return try T.init(from: _Decoder(data: data, json: self.jsonDecoder))
+            return try T.init(from: _Decoder(data: data, json: self.json))
         }
     }
 

--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -8,7 +8,7 @@ public final class PostgresDataDecoder {
     public init(json: PostgresNIO.PostgresJSONDecoder = PostgresNIO._defaultJSONDecoder) {
         self.json = json
     }
-    
+
     public func decode<T>(_ type: T.Type, from data: PostgresData) throws -> T
         where T: Decodable
     {

--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -4,11 +4,11 @@ import var PostgresNIO._defaultJSONDecoder
 
 public final class PostgresDataDecoder {
     public let json: PostgresNIO.PostgresJSONDecoder
-    
+
     public init(json: PostgresNIO.PostgresJSONDecoder = PostgresNIO._defaultJSONDecoder) {
         self.json = json
     }
-
+    
     public func decode<T>(_ type: T.Type, from data: PostgresData) throws -> T
         where T: Decodable
     {

--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -1,9 +1,10 @@
 import Foundation
+import protocol PostgresNIO.PostgresJSONDecoder
 
 public final class PostgresDataDecoder {
-    public let jsonDecoder: JSONDecoder
+    public let jsonDecoder: PostgresNIO.PostgresJSONDecoder
 
-    public init(json: JSONDecoder = JSONDecoder()) {
+    public init(json: PostgresNIO.PostgresJSONDecoder = PostgresNIO._defaultJSONDecoder) {
         self.jsonDecoder = json
     }
 
@@ -47,9 +48,9 @@ public final class PostgresDataDecoder {
         }
 
         let data: PostgresData
-        let json: JSONDecoder
+        let json: PostgresJSONDecoder
 
-        init(data: PostgresData, json: JSONDecoder) {
+        init(data: PostgresData, json: PostgresJSONDecoder) {
             self.data = data
             self.json = json
         }
@@ -93,7 +94,7 @@ public final class PostgresDataDecoder {
         var currentIndex: Int = 0
 
         let data: [PostgresData]
-        let json: JSONDecoder
+        let json: PostgresJSONDecoder
         var codingPath: [CodingKey] {
             []
         }
@@ -128,7 +129,7 @@ public final class PostgresDataDecoder {
 
     struct _ValueDecoder: SingleValueDecodingContainer {
         let data: PostgresData
-        let json: JSONDecoder
+        let json: PostgresJSONDecoder
         var codingPath: [CodingKey] {
             []
         }

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -1,9 +1,10 @@
 import Foundation
+import protocol PostgresNIO.PostgresJSONEncoder
 
 public final class PostgresDataEncoder {
-    public let json: JSONEncoder
+    public let json: PostgresJSONEncoder
 
-    public init(json: JSONEncoder = JSONEncoder()) {
+    public init(json: PostgresJSONEncoder = PostgresNIO._defaultJSONEncoder) {
         self.json = json
     }
 

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import protocol PostgresNIO.PostgresJSONEncoder
+import var PostgresNIO._defaultJSONEncoder
 
 public final class PostgresDataEncoder {
     public let json: PostgresJSONEncoder


### PR DESCRIPTION
This adds support for using non-Foundation JSON coders when decoding and encoding JSON columns (#195).

For example, if you want to use the [pure-swift JSON coders](https://github.com/fabianfett/pure-swift-json), you can now do this during the configuration of your application:
```swift
import PureSwiftJSON

PostgresNIO._defaultJSONDecoder = PSJSONDecoder()
PostgresNIO._defaultJSONEncoder = PSJSONEncoder()
``` 
**Do note that the JSON coders used here MUST be thread safe internally.**

