### PR TITLE
Use correct minimal dependency of PostgresNIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "PostgresKit", targets: ["PostgresKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.4.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.5.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],


### PR DESCRIPTION
PostgresKit relies on APIs introduced in PostgresNIO 1.4.0 and `Package.swift` now reflects that (#200, fixes #199).