### PR TITLE
Add static `ianaPortNumber` property to `PostgresConfiguration`

### DIFF
--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -10,8 +10,11 @@ public struct PostgresConfiguration {
     /// Optional `search_path` to set on new connections.
     public var searchPath: [String]?
 
-    internal var _hostname: String?
+    /// IANA-assigned port number for PostgreSQL
+    /// `UInt16(getservbyname("postgresql", "tcp").pointee.s_port).byteSwapped`
+    public static var ianaPortNumber: Int { 5432 }
 
+    internal var _hostname: String?
 
     public init?(url: String) {
         guard let url = URL(string: url) else {
@@ -31,7 +34,7 @@ public struct PostgresConfiguration {
         guard let hostname = url.host else {
             return nil
         }
-        let port = url.port ?? 5432
+        let port = url.port ?? Self.ianaPortNumber
         
         let tlsConfiguration: TLSConfiguration?
         if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {
@@ -68,7 +71,7 @@ public struct PostgresConfiguration {
     
     public init(
         hostname: String,
-        port: Int = 5432,
+        port: Int = Self.ianaPortNumber,
         username: String,
         password: String? = nil,
         database: String? = nil,

--- a/Tests/PostgresKitTests/Utilities.swift
+++ b/Tests/PostgresKitTests/Utilities.swift
@@ -4,7 +4,7 @@ extension PostgresConnection {
     static func test(on eventLoop: EventLoop) -> EventLoopFuture<PostgresConnection> {
         do {
             let address: SocketAddress
-            address = try .makeAddressResolvingHost(hostname, port: 5432)
+            address = try .makeAddressResolvingHost(hostname, port: PostgresConfiguration.ianaPortNumber)
             return connect(to: address, on: eventLoop).flatMap { conn in
                 return conn.authenticate(
                     username: "vapor_username",
@@ -22,7 +22,7 @@ extension PostgresConfiguration {
     static var test: Self {
         .init(
             hostname: hostname,
-            port: 5432,
+            port: Self.ianaPortNumber,
             username: "vapor_username",
             password: "vapor_password",
             database: "vapor_database"


### PR DESCRIPTION
Allows referencing the default PostgreSQL TCP port number (as assigned by the IANA) without hardcoding the number `5432` all over the place.