### PR TITLE
Fix passing the logger through on `PostgresConnectionSource`

### DIFF
--- a/Sources/PostgresKit/PostgresConnectionSource.swift
+++ b/Sources/PostgresKit/PostgresConnectionSource.swift
@@ -19,7 +19,7 @@ public struct PostgresConnectionSource: ConnectionPoolSource {
             to: address,
             tlsConfiguration: self.configuration.tlsConfiguration,
             serverHostname: self.configuration._hostname,
-            logger: .init(label: "codes.vapor.postgres"),
+            logger: logger,
             on: eventLoop
         ).flatMap { conn in
             return conn.authenticate(


### PR DESCRIPTION
Pass the correct logger through to `PostgresConnectionSource` to bring it in line with [MySQLKit](https://github.com/vapor/mysql-kit/blob/master/Sources/MySQLKit/MySQLConnectionSource.swift#L21).
