### PR TITLE
Fix `TLSConfiguration.forClient()` deprecation

### DIFF
--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -38,7 +38,7 @@ public struct PostgresConfiguration {
         
         let tlsConfiguration: TLSConfiguration?
         if url.query?.contains("ssl=true") == true || url.query?.contains("sslmode=require") == true {
-            tlsConfiguration = TLSConfiguration.forClient()
+            tlsConfiguration = TLSConfiguration.makeClientConfiguration()
         } else {
             tlsConfiguration = nil
         }


### PR DESCRIPTION
Fixes:

```
warning: 'forClient(cipherSuites:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:certificateChain:privateKey:applicationProtocols:shutdownTimeout:keyLogCallback:)' is deprecated: renamed to 'makeClientConfiguration()'
```