### PR TITLE
Declare supported UNION features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.4.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.12.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/PostgresKit/PostgresDialect.swift
+++ b/Sources/PostgresKit/PostgresDialect.swift
@@ -55,4 +55,8 @@ public struct PostgresDialect: SQLDialect {
     public var upsertSyntax: SQLUpsertSyntax {
         .standard
     }
+    
+    public var unionFeatures: SQLUnionFeatures {
+        [.union, .unionAll, .intersect, .intersectAll, .except, .exceptAll, .explicitDistinct, .parenthesizedSubqueries]
+    }
 }

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -7,7 +7,6 @@ class PostgresKitTests: XCTestCase {
     func testSQLKitBenchmark() throws {
         let conn = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
-        conn.logger.logLevel = .trace
         let benchmark = SQLBenchmarker(on: conn.sql())
         try benchmark.run()
     }
@@ -24,7 +23,7 @@ class PostgresKitTests: XCTestCase {
         // which causes XCTest to bail due to the first measurement having a very high deviation.
         // Spin the pool a bit before running the measurement to warm it up.
         for _ in 1...25 {
-            _ = try! pool.withConnection { conn in
+            _ = try pool.withConnection { conn in
                 return conn.query("SELECT 1;")
             }.wait()
         }
@@ -91,7 +90,6 @@ class PostgresKitTests: XCTestCase {
     func testArrayEncoding() throws {
         let conn = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
-        conn.logger.logLevel = .trace
         
         struct Foo: Codable {
             var bar: Int
@@ -104,7 +102,6 @@ class PostgresKitTests: XCTestCase {
     func testDictionaryEncoding() throws {
         let conn = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
-        conn.logger.logLevel = .trace
 
         struct Foo: Codable {
             var bar: Int


### PR DESCRIPTION
Leverages the new dialect flags from [vapor/sql-kit#144](https://github.com/vapor/sql-kit#144) to enable full `UNION` queries according to PostgreSQL's support.

The increased SQLKit version requirement makes this a `semver-minor` change.