### PR TITLE
Add support for nested JSON

### DIFF
--- a/Sources/PostgresKit/PostgresDataDecoder.swift
+++ b/Sources/PostgresKit/PostgresDataDecoder.swift
@@ -40,14 +40,11 @@ public final class PostgresDataDecoder {
 
     enum Error: Swift.Error, CustomStringConvertible {
         case unexpectedDataType(PostgresDataType, expected: String)
-        case nestingNotSupported
 
         var description: String {
             switch self {
             case .unexpectedDataType(let type, let expected):
                 return "Unexpected data type: \(type). Expected \(expected)."
-            case .nestingNotSupported:
-                return "Decoding nested containers is not supported."
             }
         }
     }
@@ -100,15 +97,15 @@ public final class PostgresDataDecoder {
             }
             
             mutating func nestedContainer<NewKey: CodingKey>(keyedBy _: NewKey.Type) throws -> KeyedDecodingContainer<NewKey> {
-                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Data nesting is not supported")
+                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Nested data types must be JSON-encoded")
             }
             
             mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Data nesting is not supported")
+                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Nested data types must be JSON-encoded")
             }
             
             mutating func superDecoder() throws -> Decoder {
-                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Data nesting is not supported")
+                throw DecodingError.dataCorruptedError(in: self, debugDescription: "Nested data types must be JSON-encoded")
             }
         }
         

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -172,6 +172,7 @@ public final class PostgresDataEncoder {
     }
 }
 
+/// Coding key for JSON types.
 internal struct _PostgresJSONKey: CodingKey {
 	public var stringValue: String
 	public var intValue: Int?
@@ -199,7 +200,7 @@ internal struct _PostgresJSONKey: CodingKey {
 	internal static let `super` = _PostgresJSONKey(stringValue: "super")!
 }
 
-///
+/// A protocol to simplify things for types that need to deal with encoders.
 private protocol _SpecialEncoder {
 	/// The coding path of the encoder.
 	var codingPath: [CodingKey] { get }
@@ -209,6 +210,10 @@ private protocol _SpecialEncoder {
 
 
 extension _SpecialEncoder {
+	/** Gets an encoder using the current object's coding path, optionally adding another `CodingKey` to the new encoder's path.
+	 - Parameter additionalKey: A `CodingKey` you'd like to add to the coding path to create an encoder from.
+	 - Returns: A `PostgresDataEncoder._Encoder` object at the object's coding path.
+	 */
 	fileprivate func getEncoder(for additionalKey: CodingKey?) -> PostgresDataEncoder._Encoder {
 		if let additionalKey = additionalKey {
 			var newCodingPath = self.codingPath

--- a/Sources/PostgresKit/PostgresDataEncoder.swift
+++ b/Sources/PostgresKit/PostgresDataEncoder.swift
@@ -14,7 +14,7 @@ public final class PostgresDataEncoder {
             return data
         } else {
             let context = _Context()
-			try value.encode(to: _Encoder(codingPath: [], context: context))
+            try value.encode(to: _Encoder(codingPath: [], context: context))
             if let value = context.value {
                 return value
             } else if let array = context.array {
@@ -38,9 +38,9 @@ public final class PostgresDataEncoder {
         var userInfo: [CodingUserInfoKey : Any] {
             [:]
         }
-		var impl: _Encoder {
-			self
-		}
+        var impl: _Encoder {
+            self
+        }
 
         let codingPath: [CodingKey]
         let context: _Context
@@ -53,7 +53,7 @@ public final class PostgresDataEncoder {
 
         func unkeyedContainer() -> UnkeyedEncodingContainer {
             self.context.array = []
-			return _UnkeyedEncodingContainer(impl: self, codingPath: self.codingPath, context: self.context)
+            return _UnkeyedEncodingContainer(impl: self, codingPath: self.codingPath, context: self.context)
         }
 
         func singleValueContainer() -> SingleValueEncodingContainer {
@@ -61,8 +61,8 @@ public final class PostgresDataEncoder {
         }
     }
 
-	struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer, _SpecialEncoder {
-		let impl: PostgresDataEncoder._Encoder
+    struct _UnkeyedEncodingContainer: UnkeyedEncodingContainer, _SpecialEncoder {
+        let impl: PostgresDataEncoder._Encoder
 
         let codingPath: [CodingKey]
 
@@ -85,27 +85,27 @@ public final class PostgresDataEncoder {
         ) -> KeyedEncodingContainer<NestedKey>
             where NestedKey : CodingKey
         {
-			let newPath = self.codingPath + [_PostgresJSONKey(index: self.count)]
-			let nestedContainer = _KeyedEncodingContainer<NestedKey>(impl: impl, codingPath: newPath)
-			return KeyedEncodingContainer(nestedContainer)
+            let newPath = self.codingPath + [_PostgresJSONKey(index: self.count)]
+            let nestedContainer = _KeyedEncodingContainer<NestedKey>(impl: impl, codingPath: newPath)
+            return KeyedEncodingContainer(nestedContainer)
         }
 
         func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-			let newPath = self.codingPath + [_PostgresJSONKey(index: self.count)]
-			let nestedContainer = _UnkeyedEncodingContainer(impl: impl, codingPath: newPath, context: context)
-			return nestedContainer
+            let newPath = self.codingPath + [_PostgresJSONKey(index: self.count)]
+            let nestedContainer = _UnkeyedEncodingContainer(impl: impl, codingPath: newPath, context: context)
+            return nestedContainer
         }
 
         func superEncoder() -> Encoder {
-			let encoder = self.getEncoder(for: _PostgresJSONKey(index: self.count))
-			return encoder
+            let encoder = self.getEncoder(for: _PostgresJSONKey(index: self.count))
+            return encoder
         }
     }
 
     struct _KeyedEncodingContainer<Key>: KeyedEncodingContainerProtocol, _SpecialEncoder
         where Key: CodingKey
-	{
-		let impl: PostgresDataEncoder._Encoder
+    {
+        let impl: PostgresDataEncoder._Encoder
 
         let codingPath: [CodingKey]
 
@@ -123,26 +123,26 @@ public final class PostgresDataEncoder {
         ) -> KeyedEncodingContainer<NestedKey>
             where NestedKey : CodingKey
         {
-			let newPath = self.codingPath + [key]
-			let nestedContainer = _KeyedEncodingContainer<NestedKey>(impl: impl, codingPath: newPath)
-			return KeyedEncodingContainer(nestedContainer)
+            let newPath = self.codingPath + [key]
+            let nestedContainer = _KeyedEncodingContainer<NestedKey>(impl: impl, codingPath: newPath)
+            return KeyedEncodingContainer(nestedContainer)
         }
 
         func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-			let newPath = self.codingPath + [key]
-			let nestedContainer = _UnkeyedEncodingContainer(impl: impl, codingPath: newPath, context: .init())
-			return nestedContainer
+            let newPath = self.codingPath + [key]
+            let nestedContainer = _UnkeyedEncodingContainer(impl: impl, codingPath: newPath, context: .init())
+            return nestedContainer
         }
 
         func superEncoder() -> Encoder {
-			superEncoder(forKey: .init(stringValue: "super")!)
+            superEncoder(forKey: .init(stringValue: "super")!)
         }
 
         func superEncoder(forKey key: Key) -> Encoder {
-			let newEncoder = self.getEncoder(for: key)
-			// self.object.set(newEncoder, for: convertedKey.stringValue)
-			return newEncoder
-		}
+            let newEncoder = self.getEncoder(for: key)
+            // self.object.set(newEncoder, for: convertedKey.stringValue)
+            return newEncoder
+        }
     }
 
 
@@ -174,53 +174,53 @@ public final class PostgresDataEncoder {
 
 /// Coding key for JSON types.
 internal struct _PostgresJSONKey: CodingKey {
-	public var stringValue: String
-	public var intValue: Int?
+    public var stringValue: String
+    public var intValue: Int?
 
-	public init?(stringValue: String) {
-		self.stringValue = stringValue
-		self.intValue = nil
-	}
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
 
-	public init?(intValue: Int) {
-		self.stringValue = "\(intValue)"
-		self.intValue = intValue
-	}
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
 
-	public init(stringValue: String, intValue: Int?) {
-		self.stringValue = stringValue
-		self.intValue = intValue
-	}
+    public init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
 
-	internal init(index: Int) {
-		self.stringValue = "Index \(index)"
-		self.intValue = index
-	}
+    internal init(index: Int) {
+        self.stringValue = "Index \(index)"
+        self.intValue = index
+    }
 
-	internal static let `super` = _PostgresJSONKey(stringValue: "super")!
+    internal static let `super` = _PostgresJSONKey(stringValue: "super")!
 }
 
 /// A protocol to simplify things for types that need to deal with encoders.
 private protocol _SpecialEncoder {
-	/// The coding path of the encoder.
-	var codingPath: [CodingKey] { get }
-	/// The associated `PostgresDataEncoder._Encoder` object.
-	var impl: PostgresDataEncoder._Encoder { get }
+    /// The coding path of the encoder.
+    var codingPath: [CodingKey] { get }
+    /// The associated `PostgresDataEncoder._Encoder` object.
+    var impl: PostgresDataEncoder._Encoder { get }
 }
 
 
 extension _SpecialEncoder {
-	/** Gets an encoder using the current object's coding path, optionally adding another `CodingKey` to the new encoder's path.
-	 - Parameter additionalKey: A `CodingKey` you'd like to add to the coding path to create an encoder from.
-	 - Returns: A `PostgresDataEncoder._Encoder` object at the object's coding path.
-	 */
-	fileprivate func getEncoder(for additionalKey: CodingKey?) -> PostgresDataEncoder._Encoder {
-		if let additionalKey = additionalKey {
-			var newCodingPath = self.codingPath
-			newCodingPath.append(additionalKey)
-			return PostgresDataEncoder._Encoder(codingPath: newCodingPath, context: .init())
-		}
+    /** Gets an encoder using the current object's coding path, optionally adding another `CodingKey` to the new encoder's path.
+     - Parameter additionalKey: A `CodingKey` you'd like to add to the coding path to create an encoder from.
+     - Returns: A `PostgresDataEncoder._Encoder` object at the object's coding path.
+     */
+    fileprivate func getEncoder(for additionalKey: CodingKey?) -> PostgresDataEncoder._Encoder {
+        if let additionalKey = additionalKey {
+            var newCodingPath = self.codingPath
+            newCodingPath.append(additionalKey)
+            return PostgresDataEncoder._Encoder(codingPath: newCodingPath, context: .init())
+        }
 
-		return self.impl
-	}
+        return self.impl
+    }
 }

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -87,6 +87,7 @@ class PostgresKitTests: XCTestCase {
         }
     }
 
+	// MARK: - Flat Tests
     func testArrayEncoding() throws {
         let conn = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
@@ -106,6 +107,10 @@ class PostgresKitTests: XCTestCase {
         struct Foo: Codable {
             var bar: Int
         }
+
+		let foos: [String: Foo] = ["1": .init(bar: 1), "2": .init(bar: 2)]
+		try conn.sql().raw("SELECT \(bind: foos)::JSONB as foos")
+			.run().wait()
     }
 
     func testDecodeModelWithNil() throws {
@@ -153,12 +158,57 @@ class PostgresKitTests: XCTestCase {
         let rows = try connection.query("SELECT * FROM foo").wait()
         print(rows)
     }
-      
+
     func testEnum() throws {
         let connection = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! connection.close().wait() }
         try SQLBenchmarker(on: connection.sql()).testEnum()
     }
+
+	// MARK: - Nested Tests
+	func testNestedArrayEncoding() throws {
+		let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+		defer { try! conn.close().wait() }
+
+		struct Nester: Codable {
+			var foo: Foo
+			var bar: Double
+
+			struct Foo: Codable {
+				var bar: Int
+			}
+		}
+
+		let nesters: [Nester] = [
+			.init(foo: .init(bar: 1), bar: 1.0),
+			.init(foo: .init(bar: 2), bar: 2.0),
+		]
+		try conn.sql().raw("SELECT \(bind: nesters)::JSONB[] as nesters")
+			.run().wait()
+	}
+
+	func testNestedDictionaryEncoding() throws {
+		let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+		defer { try! conn.close().wait() }
+
+
+		struct Nester: Codable {
+			var foo: Foo
+			var bar: Double
+
+			struct Foo: Codable {
+				var bar: Int
+			}
+		}
+
+		// Contrived Example: The Movie
+		let nesters: [String: Nester] = [
+			"1": .init(foo: .init(bar: 1), bar: 1.0),
+			"2": .init(foo: .init(bar: 2), bar: 2.0),
+		]
+		try conn.sql().raw("SELECT \(bind: nesters)::JSONB as nesters")
+			.run().wait()
+	}
 
     var eventLoop: EventLoop { self.eventLoopGroup.next() }
     var eventLoopGroup: EventLoopGroup!

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -87,7 +87,6 @@ class PostgresKitTests: XCTestCase {
         }
     }
 
-	// MARK: - Flat Tests
     func testArrayEncoding() throws {
         let conn = try PostgresConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
@@ -165,7 +164,6 @@ class PostgresKitTests: XCTestCase {
         try SQLBenchmarker(on: connection.sql()).testEnum()
     }
 
-	// MARK: - Nested Tests
 	func testNestedArrayEncoding() throws {
 		let conn = try PostgresConnection.test(on: self.eventLoop).wait()
 		defer { try! conn.close().wait() }

--- a/Tests/PostgresKitTests/PostgresKitTests.swift
+++ b/Tests/PostgresKitTests/PostgresKitTests.swift
@@ -107,9 +107,9 @@ class PostgresKitTests: XCTestCase {
             var bar: Int
         }
 
-		let foos: [String: Foo] = ["1": .init(bar: 1), "2": .init(bar: 2)]
-		try conn.sql().raw("SELECT \(bind: foos)::JSONB as foos")
-			.run().wait()
+        let foos: [String: Foo] = ["1": .init(bar: 1), "2": .init(bar: 2)]
+        try conn.sql().raw("SELECT \(bind: foos)::JSONB as foos")
+            .run().wait()
     }
 
     func testDecodeModelWithNil() throws {
@@ -164,49 +164,49 @@ class PostgresKitTests: XCTestCase {
         try SQLBenchmarker(on: connection.sql()).testEnum()
     }
 
-	func testNestedArrayEncoding() throws {
-		let conn = try PostgresConnection.test(on: self.eventLoop).wait()
-		defer { try! conn.close().wait() }
+    func testNestedArrayEncoding() throws {
+        let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
 
-		struct Nester: Codable {
-			var foo: Foo
-			var bar: Double
+        struct Nester: Codable {
+            var foo: Foo
+            var bar: Double
 
-			struct Foo: Codable {
-				var bar: Int
-			}
-		}
+            struct Foo: Codable {
+                var bar: Int
+            }
+        }
 
-		let nesters: [Nester] = [
-			.init(foo: .init(bar: 1), bar: 1.0),
-			.init(foo: .init(bar: 2), bar: 2.0),
-		]
-		try conn.sql().raw("SELECT \(bind: nesters)::JSONB[] as nesters")
-			.run().wait()
-	}
+        let nesters: [Nester] = [
+            .init(foo: .init(bar: 1), bar: 1.0),
+            .init(foo: .init(bar: 2), bar: 2.0),
+        ]
+        try conn.sql().raw("SELECT \(bind: nesters)::JSONB[] as nesters")
+            .run().wait()
+    }
 
-	func testNestedDictionaryEncoding() throws {
-		let conn = try PostgresConnection.test(on: self.eventLoop).wait()
-		defer { try! conn.close().wait() }
+    func testNestedDictionaryEncoding() throws {
+        let conn = try PostgresConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
 
 
-		struct Nester: Codable {
-			var foo: Foo
-			var bar: Double
+        struct Nester: Codable {
+            var foo: Foo
+            var bar: Double
 
-			struct Foo: Codable {
-				var bar: Int
-			}
-		}
+            struct Foo: Codable {
+                var bar: Int
+            }
+        }
 
-		// Contrived Example: The Movie
-		let nesters: [String: Nester] = [
-			"1": .init(foo: .init(bar: 1), bar: 1.0),
-			"2": .init(foo: .init(bar: 2), bar: 2.0),
-		]
-		try conn.sql().raw("SELECT \(bind: nesters)::JSONB as nesters")
-			.run().wait()
-	}
+        // Contrived Example: The Movie
+        let nesters: [String: Nester] = [
+            "1": .init(foo: .init(bar: 1), bar: 1.0),
+            "2": .init(foo: .init(bar: 2), bar: 2.0),
+        ]
+        try conn.sql().raw("SELECT \(bind: nesters)::JSONB as nesters")
+            .run().wait()
+    }
 
     var eventLoop: EventLoop { self.eventLoopGroup.next() }
     var eventLoopGroup: EventLoopGroup!


### PR DESCRIPTION
This PR adds support for encoding nested JSON. For example, you can encode a Codable datatype that includes other Codable types.

You can use this with Codable's polymorphism support to add small bits of data that support polymorphism by having a type annotation outside a nested object you intend to decode.
