### PR TITLE
Version bump postgres-nio dependency to prevent build error against swift-nio 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "PostgresKit", targets: ["PostgresKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.4.0"),
+        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.7.2"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],


### PR DESCRIPTION
Hi folks! 

I'm not sure what this project's process for version-bumping is, but the current `vapor/postgres-nio@1.4.0` dependency can't build against the more current `swift-nio` versions because of a duplicate addition of `writeNullTerminatedString` to `ByteBuffer` by extension:

```
/path/to/.build/checkouts/postgres-nio/Sources/PostgresNIO/New/Extensions/ByteBuffer+PSQL.swift:4:19: note: found this candidate
    mutating func writeNullTerminatedString(_ string: String) {
                  ^
/path/to/.build/checkouts/swift-nio/Sources/NIOCore/ByteBuffer-aux.swift:100:26: note: found this candidate
    public mutating func writeNullTerminatedString(_ string: String) -> Int { 
```

The `postgres-nio` project has since removed the duplicate method definition, so rolling forward the dependency to `1.7.2` (in this PR) fixes the build error.



<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
