### PR TITLE
Ignore ParamaterStatus messages when handling response

### DIFF
--- a/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
+++ b/Sources/PostgreSQL/Connection/PostgreSQLConnection.swift
@@ -93,6 +93,8 @@ public final class PostgreSQLConnection: DatabaseConnection, BasicWorker, Databa
                 return true
             case .error(let e): error = PostgreSQLError.errorResponse(e)
             case .notice(let n): debugOnly { WARNING(n.description) }
+            case .parameterStatus:
+                break
             default: try onResponse(message)
             }
             return false // request until ready for query

--- a/Tests/PostgreSQLTests/ConnectionTests.swift
+++ b/Tests/PostgreSQLTests/ConnectionTests.swift
@@ -686,6 +686,11 @@ class ConnectionTests: XCTestCase {
         XCTAssertEqual(1, result.count)
         XCTAssertEqual([nil, "foo", nil, "bar"], result[0].arr)
     }
+
+    func testParameterStatus() throws {
+        let conn = try PostgreSQLConnection.makeTest()
+        try conn.query("SET TIME ZONE 'UTC';") { _ in }.wait()
+    }
 }
 
 extension PostgreSQLConnection {

--- a/Tests/PostgreSQLTests/XCTestManifests.swift
+++ b/Tests/PostgreSQLTests/XCTestManifests.swift
@@ -19,6 +19,7 @@ extension ConnectionTests {
         ("testNull", testNull),
         ("testNumericDecode", testNumericDecode),
         ("testOrderBy", testOrderBy),
+        ("testParameterStatus", testParameterStatus),
         ("testPolygon", testPolygon),
         ("testRowCodableEmptyKeyed", testRowCodableEmptyKeyed),
         ("testRowCodableNested", testRowCodableNested),


### PR DESCRIPTION
ParameterStatus messages may be generated in response to a SET command or when the administrator sends the SIGHUP signals to the server. They will appear in the query response and should be ignored.