### PR TITLE
Allow `backendKeyData` to be set

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "PostgresKit", targets: ["PostgresKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.9.0"),
+        .package(url: "https://github.com/vapor/postgres-nio.git", .revision("7fccb32")),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "PostgresKit", targets: ["PostgresKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/postgres-nio.git", .revision("7fccb32")),
+        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.11.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
     ],

--- a/Sources/PostgresKit/PostgresConfiguration.swift
+++ b/Sources/PostgresKit/PostgresConfiguration.swift
@@ -7,6 +7,12 @@ public struct PostgresConfiguration {
     public var database: String?
     public var tlsConfiguration: TLSConfiguration?
 
+    /// Require connection to provide `BackendKeyData`.
+    /// For use with Amazon RDS Proxy, this must be set to false.
+    ///
+    /// - Default: true
+    public var requireBackendKeyData: Bool = true
+
     /// Optional `search_path` to set on new connections.
     public var searchPath: [String]?
 

--- a/Sources/PostgresKit/PostgresConnectionSource.swift
+++ b/Sources/PostgresKit/PostgresConnectionSource.swift
@@ -22,10 +22,15 @@ public struct PostgresConnectionSource: ConnectionPoolSource {
                 case let .success(sslContext): tlsMode = sslContext.map { .require($0) } ?? .disable
                 case let .failure(error): return eventLoop.makeFailedFuture(error)
             }
+            
+            var connection: PostgresConnection.Configuration.Connection
+            connection = .init(host: hostname, port: self.configuration._port ?? PostgresConfiguration.ianaPortNumber)
+            connection.requireBackendKeyData = configuration.requireBackendKeyData
+            
             let future = PostgresConnection.connect(
                 on: eventLoop,
                 configuration: .init(
-                    connection: .init(host: hostname, port: self.configuration._port ?? PostgresConfiguration.ianaPortNumber),
+                    connection: connection,
                     authentication: .init(username: self.configuration.username, database: self.configuration.database, password: self.configuration.password),
                     tls: tlsMode
                 ),


### PR DESCRIPTION
This change provides access to the new functionality provided in this postgres-nio PR: https://github.com/vapor/postgres-nio/pull/296. In short, apps can enable integration with Amazon RDS Proxy by setting `requireBackendKeyData` to false. See the postgres-nio PR for more details.