### PR TITLE
Drop support for Swift 5.2/5.3 + Yet another CI overhaul

### DIFF
--- a/.github/workflows/main-codecov.yml
+++ b/.github/workflows/main-codecov.yml
@@ -1,0 +1,40 @@
+name: Update code coverage baselines
+on:
+  push: { branches: [ main ] }
+jobs:
+  update-main-codecov:
+    strategy:
+      matrix: { dbimage: ['postgres:14'], dbauth: ['scram-sha-256'] }
+    runs-on: ubuntu-latest
+    container: swift:5.6-focal
+    env:
+      LOG_LEVEL: debug
+      POSTGRES_HOSTNAME: 'psql'
+      POSTGRES_DB: 'test_database'
+      POSTGRES_USER: 'test_username'
+      POSTGRES_PASSWORD: 'test_password'
+    services:
+      psql:
+        image: ${{ matrix.dbimage }}
+        env:
+          POSTGRES_USER: 'test_username'
+          POSTGRES_DB: 'test_database'
+          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
+          POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
+    steps:
+      - name: Save Postgres version and method to env
+        run: echo POSTGRES_INFO='${{ toJSON(matrix) }}' >> $GITHUB_ENV
+      - name: Check out package
+        uses: actions/checkout@v3
+      - name: Run local tests with coverage
+        run: swift test --enable-code-coverage
+      - name: Submit coverage report to Codecov.io
+        uses: vapor/swift-codecov-action@v0.2
+        with:
+          cc_flags: 'unittests'
+          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,POSTGRES_INFO'
+          cc_fail_ci_if_error: true
+          cc_verbose: true
+          cc_dry_run: false
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
           POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
     steps:
       - name: Save Postgres version and method to env
-        run: echo POSTGRES_INFO='${{ toJSON(matrix) }}' >> $GITHUB_ENV
+        run: |
+          echo POSTGRES_VERSION='${{ matrix.dbimage }}' >> $GITHUB_ENV
+          echo POSTGRES_AUTH_METHOD='${{ matrix.dbauth }}' >> $GITHUB_ENV
       - name: Check out package
         uses: actions/checkout@v3
       - name: Run local tests with coverage
@@ -42,7 +44,7 @@ jobs:
         uses: vapor/swift-codecov-action@v0.2
         with:
           cc_flags: 'unittests'
-          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,POSTGRES_INFO'
+          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,POSTGRES_VERSION,POSTGRES_AUTH_METHOD'
           cc_fail_ci_if_error: true
           cc_verbose: true
           cc_dry_run: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,8 +150,8 @@ jobs:
         dbimage: ['postgresql']
         dbauth: ['scram-sha-256']
         macos: ['macos-11', 'macos-12']
-        xcode: ['latest-stable']
-        include: [{ macos: 'macos-12', xcode: 'latest' }]
+        xcode: ['latest-stable', 'latest']
+        exclude: [{ macos: 'macos-11', xcode: 'latest' }]
     runs-on: ${{ matrix.macos }}
     env:
       POSTGRES_HOSTNAME: 127.0.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,45 +1,116 @@
 name: test
 on: [ 'pull_request' ]
+env:
+  LOG_LEVEL: debug
+  POSTGRES_HOSTNAME: 'psql-a'
+  POSTGRES_HOSTNAME_A: 'psql-a'
+  POSTGRES_HOSTNAME_B: 'psql-b'
+  POSTGRES_DB: 'test_database'
+  POSTGRES_DB_A: 'test_database'
+  POSTGRES_DB_B: 'test_database'
+  POSTGRES_USER: 'test_username'
+  POSTGRES_USER_A: 'test_username'
+  POSTGRES_USER_B: 'test_username'
+  POSTGRES_PASSWORD: 'test_password'
+  POSTGRES_PASSWORD_A: 'test_password'
+  POSTGRES_PASSWORD_B: 'test_password'
 
 jobs:
-  linux-plus-dependents:
+  # Baseline test run for code coverage stats
+  codecov:
+    strategy:
+      matrix: { dbimage: ['postgres:14'], dbauth: ['scram-sha-256'] }
+    runs-on: ubuntu-latest
+    container: swift:5.6-focal
+    services:
+      psql-a:
+        image: ${{ matrix.dbimage }}
+        env:
+          POSTGRES_USER: 'test_username'
+          POSTGRES_DB: 'test_database'
+          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
+          POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
+    steps:
+      - name: Save Postgres version and method to env
+        run: echo POSTGRES_INFO='${{ toJSON(matrix) }}' >> $GITHUB_ENV
+      - name: Check out package
+        uses: actions/checkout@v3
+      - name: Run local tests with coverage
+        run: swift test --enable-code-coverage
+      - name: Submit coverage report to Codecov.io
+        uses: vapor/swift-codecov-action@v0.2
+        with:
+          cc_flags: 'unittests'
+          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,POSTGRES_INFO'
+          cc_fail_ci_if_error: true
+          cc_verbose: true
+          cc_dry_run: false
+
+  # Check for API breakage versus main
+  api-breakage:
+    runs-on: ubuntu-latest
+    container: swift:5.6-focal
+    steps:
+      - name: Check out package
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Check for API breaking changes
+        run: swift package diagnose-api-breaking-changes origin/main
+
+  # Run Linux unit tests against various configurations
+  linux-unit:
     strategy:
       fail-fast: false
       matrix:
-        dbimage:
-          - postgres:14
-          - postgres:13
-          - postgres:11
-        dbauth:
-          - trust
-          - md5
-          - scram-sha-256
-        swiftver:
-          - swift:5.2
-          - swift:5.5
-          - swift:5.6
-          - swiftlang/swift:nightly-main
-        swiftos:
-          - focal
-        include:
-          - swiftver: swift:5.2
-            test_flag: --enable-test-discovery
+        dbimage: ['postgres:14', 'postgres:13', 'postgres:11']
+        swiftver: ['swift:5.4', 'swift:5.5', 'swift:5.6', 'swiftlang/swift:nightly-main']
+        swiftos: ['focal']
+        include: [
+            {dbimage: 'postgres:14', dbauth: 'scram-sha-256'},
+            {dbimage: 'postgres:13', dbauth: 'md5'},
+            {dbimage: 'postgres:11', dbauth: 'trust'}
+        ]
     container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
     runs-on: ubuntu-latest
-    env:
-      LOG_LEVEL: debug
-      POSTGRES_HOSTNAME: 'psql-a'
-      POSTGRES_HOSTNAME_A: 'psql-a'
-      POSTGRES_HOSTNAME_B: 'psql-b'
-      POSTGRES_DB: 'test_database'
-      POSTGRES_DB_A: 'test_database'
-      POSTGRES_DB_B: 'test_database'
-      POSTGRES_USER: 'test_username'
-      POSTGRES_USER_A: 'test_username'
-      POSTGRES_USER_B: 'test_username'
-      POSTGRES_PASSWORD: 'test_password'
-      POSTGRES_PASSWORD_A: 'test_password'
-      POSTGRES_PASSWORD_B: 'test_password'
+    services:
+      psql-a:
+        image: ${{ matrix.dbimage }}
+        env:
+          POSTGRES_USER: 'test_username'
+          POSTGRES_DB: 'test_database'
+          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
+          POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
+      psql-b:
+        image: ${{ matrix.dbimage }}
+        env:
+          POSTGRES_USER: 'test_username'
+          POSTGRES_DB: 'test_database'
+          POSTGRES_PASSWORD: 'test_password'
+          POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
+          POSTGRES_INITDB_ARGS: --auth-host=${{ matrix.dbauth }}
+    steps:
+      - name: Check out package
+        uses: actions/checkout@v3
+      - name: Run local tests
+        run: swift test
+
+  # Test integration with dependent package on Linux
+  linux-integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        dbimage: ['postgres:14']
+        dbauth: ['scram-sha-256']
+        swiftver: ['swift:5.4', 'swift:5.5', 'swift:5.6', 'swiftlang/swift:nightly-main']
+        swiftos: ['focal']
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
+    runs-on: ubuntu-latest
     services:
       psql-a:
         image: ${{ matrix.dbimage }}
@@ -64,31 +135,24 @@ jobs:
       - name: Check out fluent-postgres-driver dependent
         uses: actions/checkout@v3
         with: { repository: 'vapor/fluent-postgres-driver', path: 'fluent-postgres-driver' }
-      - name: Run local tests with Thread Sanitizer
-        run: swift test --package-path postgres-kit ${{ matrix.test_flag }} --sanitize=thread
       - name: Use local package
         run: swift package --package-path fluent-postgres-driver edit postgres-kit --path postgres-kit
-      - name: Run fluent-postgres-kit tests with Thread Sanitizer
-        run: swift test --package-path fluent-postgres-driver ${{ matrix.test_flag }} --sanitize=thread
+      - name: Run fluent-postgres-kit tests
+        run: swift test --package-path fluent-postgres-driver
 
-  macos:
+  # Run macOS unit tests against various configurations
+  macos-unit:
     strategy:
       fail-fast: false
       matrix:
-        # Only test latest version and one auth method on macOS
-        dbimage:
-          - postgresql@14
-        dbauth:
-          - scram-sha-256
-        xcode:
-          - latest-stable
-          #- latest
-    runs-on: macos-11
+        dbimage: ['postgresql']
+        dbauth: ['scram-sha-256']
+        macos: ['macos-11', 'macos-12']
+        xcode: ['latest-stable']
+        include: [{ macos: 'macos-12', xcode: 'latest' }]
+    runs-on: ${{ matrix.macos }}
     env:
-      LOG_LEVEL: debug
       POSTGRES_HOSTNAME: 127.0.0.1
-      POSTGRES_USER: test_username
-      POSTGRES_PASSWORD: test_password
       POSTGRES_DB: postgres
       POSTGRES_HOST_AUTH_METHOD: ${{ matrix.dbauth }}
     steps:
@@ -105,7 +169,5 @@ jobs:
         timeout-minutes: 2
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Run local tests with Thread Sanitizer
-        run: |
-          swift test --sanitize=thread -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+      - name: Run local tests
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)