### PR TITLE
Add locking clause syntax to dialect

### DIFF
--- a/Sources/PostgresKit/PostgresDialect.swift
+++ b/Sources/PostgresKit/PostgresDialect.swift
@@ -59,4 +59,12 @@ public struct PostgresDialect: SQLDialect {
     public var unionFeatures: SQLUnionFeatures {
         [.union, .unionAll, .intersect, .intersectAll, .except, .exceptAll, .explicitDistinct, .parenthesizedSubqueries]
     }
+
+    public var sharedSelectLockExpression: SQLExpression? {
+        SQLRaw("FOR SHARE")
+    }
+
+    public var exclusiveSelectLockExpression: SQLExpression? {
+        SQLRaw("FOR UPDATE")
+    }
 }


### PR DESCRIPTION
Leverages the new functionality in vapor/sql-kit#154 to provide the correct syntax for both shared and exclusive locking clauses in PostgreSQL.