### PR TITLE
Migrate to Swift Atomics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,12 +13,14 @@ let package = Package(
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.11.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0")
     ],
     targets: [
         .target(name: "PostgresKit", dependencies: [
             .product(name: "AsyncKit", package: "async-kit"),
             .product(name: "PostgresNIO", package: "postgres-nio"),
             .product(name: "SQLKit", package: "sql-kit"),
+            .product(name: "Atomics", package: "swift-atomics")
         ]),
         .testTarget(name: "PostgresKitTests", dependencies: [
             .target(name: "PostgresKit"),


### PR DESCRIPTION
Fix deprecation warnings from `NIOAtomic` and migrate any uses to `swift-atomics`