### PR TITLE
Add Postgres support for nested subpath (JSON) expressions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.14.2"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.26.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.28.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.14.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0")
     ],

--- a/Sources/PostgresKit/PostgresDialect.swift
+++ b/Sources/PostgresKit/PostgresDialect.swift
@@ -54,4 +54,19 @@ public struct PostgresDialect: SQLDialect {
     public var sharedSelectLockExpression: (any SQLExpression)? { SQLRaw("FOR SHARE") }
 
     public var exclusiveSelectLockExpression: (any SQLExpression)? { SQLRaw("FOR UPDATE") }
+
+    public func nestedSubpathExpression(in column: any SQLExpression, for path: [String]) -> (any SQLExpression)? {
+        guard !path.isEmpty else { return nil }
+        
+        let descender = SQLList(
+            [column] + path.dropLast().map(SQLLiteral.string(_:)),
+            separator: SQLRaw("->")
+        )
+        let accessor = SQLList(
+            [descender, SQLLiteral.string(path.last!)],
+            separator: SQLRaw("->>")
+        )
+        
+        return SQLGroupExpression(accessor)
+    }
 }


### PR DESCRIPTION
Implements SQLKit's new `SQLDialect.nestedSubpathExpression(in:for:)` method.