### PR TITLE
Enable libpq-compatible "postgresql" URL schemes

### DIFF
--- a/Sources/PostgresKit/SQLPostgresConfiguration.swift
+++ b/Sources/PostgresKit/SQLPostgresConfiguration.swift
@@ -64,6 +64,8 @@ public struct SQLPostgresConfiguration {
     /// The aliases always have the same semantics as the "canonical" modes, despite any differences
     /// suggested by their names.
     ///
+    /// Also for compatibility, the URL scheme may also be `postgresql` or `postgresql+uds`.
+    ///
     /// > Note: It is possible to emulate `libpq`'s definitions for `prefer` (TLS if available with
     /// > no certificate verification), `require` (TLS enforced, but also without certificate
     /// > verification) and `verify-ca` (TLS enforced with no hostname verification) by manually
@@ -94,7 +96,7 @@ public struct SQLPostgresConfiguration {
         }
         
         switch comp.scheme {
-        case "postgres", "postgres+tcp":
+        case "postgres", "postgres+tcp", "postgresql", "postgresql+tcp":
             guard let hostname = comp.host, !hostname.isEmpty else {
                 throw URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: url, NSURLErrorFailingURLStringErrorKey: url.absoluteString])
             }
@@ -104,7 +106,7 @@ public struct SQLPostgresConfiguration {
                 database: url.lastPathComponent.isEmpty ? nil : url.lastPathComponent,
                 tls: try decideTLSConfig(from: comp.queryItems ?? [], defaultMode: "prefer")
             )
-        case "postgres+uds":
+        case "postgres+uds", "postgresql+uds":
             guard (comp.host?.isEmpty ?? true || comp.host == "localhost"), comp.port == nil, !comp.path.isEmpty, comp.path != "/" else {
                 throw URLError(.badURL, userInfo: [NSURLErrorFailingURLErrorKey: url, NSURLErrorFailingURLStringErrorKey: url.absoluteString])
             }

--- a/Tests/PostgresKitTests/SQLPostgresConfigurationTests.swift
+++ b/Tests/PostgresKitTests/SQLPostgresConfigurationTests.swift
@@ -61,9 +61,9 @@ final class SQLPostgresConfigurationTests: XCTestCase {
             XCTAssertTrue(config.coreConfiguration.tls.isEnforced)
         }
         
-        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql://test_username@test_hostname"))
-        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql+tcp://test_username@test_hostname"))
-        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql+uds://test_username@/tmp/postgres.sock"))
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url: "postgresql://test_username@test_hostname"))
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url: "postgresql+tcp://test_username@test_hostname"))
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url: "postgresql+uds://test_username@/tmp/postgres.sock"))
         
         XCTAssertThrowsError(try SQLPostgresConfiguration(url: "postgres+tcp://test_hostname"), "should fail when username missing")
         XCTAssertThrowsError(try SQLPostgresConfiguration(url: "postgres+tcp://test_username@test_hostname?tlsmode=absurd"), "should fail when TLS mode invalid")

--- a/Tests/PostgresKitTests/SQLPostgresConfigurationTests.swift
+++ b/Tests/PostgresKitTests/SQLPostgresConfigurationTests.swift
@@ -61,6 +61,10 @@ final class SQLPostgresConfigurationTests: XCTestCase {
             XCTAssertTrue(config.coreConfiguration.tls.isEnforced)
         }
         
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql://test_username@test_hostname"))
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql+tcp://test_username@test_hostname"))
+        XCTAssertNoThrow(try SQLPostgresConfiguration(url:"postgresql+uds://test_username@/tmp/postgres.sock"))
+        
         XCTAssertThrowsError(try SQLPostgresConfiguration(url: "postgres+tcp://test_hostname"), "should fail when username missing")
         XCTAssertThrowsError(try SQLPostgresConfiguration(url: "postgres+tcp://test_username@test_hostname?tlsmode=absurd"), "should fail when TLS mode invalid")
         XCTAssertThrowsError(try SQLPostgresConfiguration(url: "postgres+uds://localhost/tmp/postgres.sock?tlsmode=require"), "should fail when username missing")


### PR DESCRIPTION
For [libpq compatibility](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), the following additional schemes are now accepted in database URLs:

- `"postgresql"`
- `"postgresql+tcp"`
- `"postgresql+uds"`

Fixes #250.