### PR TITLE
Remove redundant Sendable conformance

### DIFF
--- a/Sources/PostgresKit/PostgresDatabase+SQL.swift
+++ b/Sources/PostgresKit/PostgresDatabase+SQL.swift
@@ -2,13 +2,6 @@ import PostgresNIO
 import Logging
 import SQLKit
 
-// https://github.com/vapor/postgres-nio/pull/450
-#if compiler(>=5.10) && $RetroactiveAttribute
-extension PostgresEncodingContext: @retroactive @unchecked Sendable {}
-#else
-extension PostgresEncodingContext: @unchecked Sendable {}
-#endif
-
 extension PostgresDatabase {
     @inlinable
     public func sql(queryLogLevel: Logger.Level? = .debug) -> some SQLDatabase {


### PR DESCRIPTION
We no longer need to retroactively conform `PostgresEncodingContext` to `Sendable`; we already require a version of `PostgresNIO` newer than the one that includes it natively.

This change has no functional impact and does not affect any warnings, and thus does not require a release.