### PR TITLE
Override SQLDataType.blob to BYTEA for SQLKit users

### DIFF
--- a/Sources/PostgresKit/PostgresDialect.swift
+++ b/Sources/PostgresKit/PostgresDialect.swift
@@ -72,6 +72,8 @@ public struct PostgresDialect: SQLDialect {
     public func customDataType(for dataType: SQLDataType) -> (any SQLExpression)? {
         if case let .custom(expr) = dataType, (expr as? SQLRaw)?.sql == "TIMESTAMP" {
             return SQLRaw("TIMESTAMPTZ")
+        } else if case .blob = dataType {
+            return SQLRaw("BYTEA")
         } else {
             return nil
         }


### PR DESCRIPTION
Fluent already does this for users of FluentPostgresDriver, this just adds the same behavior to the equivalent data type at the SQLKit layer.