### PR TITLE
Use logging metadata when logging queries

### DIFF
--- a/Sources/PostgresKit/PostgresDatabase+SQL.swift
+++ b/Sources/PostgresKit/PostgresDatabase+SQL.swift
@@ -45,7 +45,7 @@ extension PostgresSQLDatabase: SQLDatabase, PostgresDatabase {
         let (sql, binds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) [\(binds)]")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(binds.map { .string("\($0)") })])
         }
         return self.eventLoop.makeCompletedFuture {
             var bindings = PostgresBindings(capacity: binds.count)
@@ -69,7 +69,7 @@ extension PostgresSQLDatabase: SQLDatabase, PostgresDatabase {
         let (sql, binds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) [\(binds)]")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(binds.map { .string("\($0)") })])
         }
 
         var bindings = PostgresBindings(capacity: binds.count)


### PR DESCRIPTION
When a query is executed, the actual SQL query and its accompanying array of bound parameters (if any) are now logged as structured metadata on the logger using a generic message, rather than the query and bindings being the message. This follows the [recommended guidelines for logging in libraries](https://www.swift.org/documentation/server/guides/libraries/log-levels.html). Credit goes to @MahdiBM for the original suggestion.

Before:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=psql [PostgresKit] SELECT * FROM foo WHERE a=$1 [["bar"]]
```
After:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=psql sql=SELECT * FROM foo WHERE a=$1 binds=["bar"] [PostgresKit] Executing query
```
